### PR TITLE
bundle/configを追加

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,4 @@
+---
+BUNDLE_PATH: vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: true
+BUNDLE_BIN: vendor/bundle/bin


### PR DESCRIPTION
.bundle/configを作ることで以下のことを設定する。
bundle installしたものを vender/bundle/binに入れる
globalなgemを使わない
bundle execのパスにvender/bundle以下を使う
